### PR TITLE
Remove unnecessary escaping

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -56,7 +56,7 @@ class Bot:
         # Get all possible matches
         possible_matches = self.cursor.execute(
             """SELECT * FROM tags WHERE tag LIKE (?) AND software=(?)""", ('%'+text_escaped+'%', subreddit)).fetchall()
-        # print(text, "=>", possible_matches)
+        print(text, "=>", possible_matches)
 
         # Nothing found
         if len(possible_matches) == 0:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -51,12 +51,11 @@ class Bot:
         if subreddit not in ["vim", "neovim"]:
             subreddit = "vim"
 
-        text_escaped = text.replace("%", "\\%").replace("_", "\\_")
-        text_escaped = text_escaped.replace('"', "quote")
+        text_escaped = text.replace('"', "quote")
 
         # Get all possible matches
         possible_matches = self.cursor.execute(
-            """SELECT * FROM tags WHERE tag LIKE (?) ESCAPE '\\' AND software=(?)""", ('%'+text_escaped+'%', subreddit)).fetchall()
+            """SELECT * FROM tags WHERE tag LIKE (?) AND software=(?)""", ('%'+text_escaped+'%', subreddit)).fetchall()
         # print(text, "=>", possible_matches)
 
         # Nothing found

--- a/test_bot.py
+++ b/test_bot.py
@@ -28,7 +28,7 @@ class TestBot(unittest.TestCase):
         tests_vim = {"number": ":number", "usr_01.txt": "usr_01.txt",
                      "num": "+num64", "NUm": "Number", "Num": "Number",
                      "<_": "v_b_<_example", "hl": "'hl'", "\".": "quote.",
-                     "\"=": "quote=", ":execute": ":execute", "/\<": "/\<"}
+                     "\"=": "quote=", ":execute": ":execute", "/\<": "/\<", "%:.": "%:.", "_%": ":_%"}
         for k, v in tests_vim.items():
             result = bot.search_tag(k)
             print(k, "=>", result)

--- a/test_bot.py
+++ b/test_bot.py
@@ -25,8 +25,10 @@ class TestBot(unittest.TestCase):
         bot = Bot()
 
         # TODO Add more tests
-        tests_vim = {"number": ":number", "usr_01.txt": "usr_01.txt", "num": "+num64", "NUm": "Number",
-                     "Num": "Number", "<_": "v_b_<_example", "hl": "'hl'", "\".": "quote.", "\"=": "quote=", ":execute": ":execute"}
+        tests_vim = {"number": ":number", "usr_01.txt": "usr_01.txt",
+                     "num": "+num64", "NUm": "Number", "Num": "Number",
+                     "<_": "v_b_<_example", "hl": "'hl'", "\".": "quote.",
+                     "\"=": "quote=", ":execute": ":execute", "/\<": "/\<"}
         for k, v in tests_vim.items():
             result = bot.search_tag(k)
             print(k, "=>", result)


### PR DESCRIPTION
Also adds a test case for `:help /\<`.

Resolves #16