### PR TITLE
Parse "tags" files instead of help files, change third party repository locations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ praw.ini
 __pycache__/*
 bot/__pycache__/*
 .vscode
+third_party/

--- a/help_tag_extractor.py
+++ b/help_tag_extractor.py
@@ -1,6 +1,5 @@
 import re
 import sqlite3
-import subprocess
 
 tag_re = re.compile(r'^(\S+)\s*(\S+).txt', re.MULTILINE)
 def add_tags(software):

--- a/help_tag_extractor.py
+++ b/help_tag_extractor.py
@@ -1,28 +1,30 @@
 import re
-import glob
 import sqlite3
+import subprocess
 
-def add_tag(doc, software):
-    with open(doc) as f:
-        text = f.read()
-        
-        match_re = re.compile(r'(?:^|\s)\*(\S*?)\*(?=\s)')
-        matches = match_re.findall(text)
-        for m in matches:
-            doc = doc.split("/")[-1].split(".")[0]
-            t = (doc, m, software)
-            c.execute("INSERT OR REPLACE INTO tags VALUES (?,?,?)", t)
-            print("{}/{} => {}".format(software,doc, m))
+tag_re = re.compile(r'^(\S+)\s*(\S+).txt', re.MULTILINE)
+def add_tags(software):
+        with open('~/' + software + '/runtime/doc/tags') as f:
+                text = f.read()
 
-conn = sqlite3.connect('../tags.db')
+                matches = tag_re.findall(text)
+
+                for m in matches:
+                    # db entry: (doc, tag, software)
+                    entry = (m[1], m[0], software)
+
+                    c.execute('INSERT OR REPLACE INTO tags VALUES (?,?,?)', entry)
+                    print('{}/{} => {}'.format(software, m[1], m[0]))
+
+conn = sqlite3.connect('tags.db')
 c = conn.cursor()
 c.execute("CREATE TABLE IF NOT EXISTS tags(filename text, tag text, software text)")
-files = glob.glob("../vim/runtime/doc/*.txt")
-for doc in files:
-    add_tag(doc, "vim")
 
-files = glob.glob("../neovim/runtime/doc/*.txt")
-for doc in files:
-    add_tag(doc, "neovim")
+# list of supported softwares
+softwares = ['vim', 'neovim']
+
+for software in softwares:
+        add_tags(software)
+
 conn.commit()
 conn.close()

--- a/help_tag_extractor.py
+++ b/help_tag_extractor.py
@@ -4,7 +4,7 @@ import subprocess
 
 tag_re = re.compile(r'^(\S+)\s*(\S+).txt', re.MULTILINE)
 def add_tags(software):
-        with open('~/' + software + '/runtime/doc/tags') as f:
+        with open('third_party/' + software + '/runtime/doc/tags') as f:
                 text = f.read()
 
                 matches = tag_re.findall(text)

--- a/update_tags.sh
+++ b/update_tags.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 
-# clone (Neo)Vim if it doesn't exist
-[ -d third_party/vim ] || git clone https://github.com/vim/vim.git third_party/vim
-[ -d third_party/neovim ] || git clone https://github.com/neovim/neovim.git third_party/neovim
+# clone Vim if it doesn't exist, else pull most recent version
+if [ ! -d third_party/vim ]; then
+    git clone https://github.com/vim/vim.git third_party/vim
+else
+    git -C third_party/vim pull
+fi
 
-# make sure (Neo)Vim are up to date
-git -C third_party/vim pull
-git -C third_party/neovim pull
+# clone Neovim if it doesn't exist, else pull most recent version
+if [ ! -d third_party/neovim ]; then
+    git clone https://github.com/neovim/neovim.git third_party/neovim
+else
+    # store output of git pull
+    nvim_status=$(git -C third_party/neovim pull | tee /dev/tty)
+fi
 
-# build helptags for Neovim (Vim repo comes with 'tags' file)
-vim --clean -e --cmd 'helptags third_party/neovim/runtime/doc | quit'
+# build helptags for Neovim, if needed (Vim repo comes with 'tags' file)
+if [ "$nvim_status" != "Already up to date." ]; then
+    vim --clean -e --cmd 'helptags third_party/neovim/runtime/doc | quit'
+fi
 
 python help_tag_extractor.py

--- a/update_tags.sh
+++ b/update_tags.sh
@@ -8,8 +8,7 @@
 git -C third_party/vim pull
 git -C third_party/neovim pull
 
-# build helptags for (Neo)Vim
-vim --clean -e --cmd 'helptags third_party/vim/runtime/doc | quit'
+# build helptags for Neovim (Vim repo comes with 'tags' file)
 vim --clean -e --cmd 'helptags third_party/neovim/runtime/doc | quit'
 
 python help_tag_extractor.py

--- a/update_tags.sh
+++ b/update_tags.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-[ -d ~/vim ] || git clone https://github.com/vim/vim.git
-[ -d ~/neovim ] || git clone https://github.com/neovim/neovim.git
+# clone (Neo)Vim if it doesn't exist
+[ -d third_party/vim ] || git clone https://github.com/vim/vim.git third_party/vim
+[ -d third_party/neovim ] || git clone https://github.com/neovim/neovim.git third_party/neovim
 
-cd ~/vim && git pull
-cd ~/neovim && git pull
+# make sure (Neo)Vim are up to date
+git -C third_party/vim pull
+git -C third_party/neovim pull
 
-cd ~/VimHelpBot && python help_tag_extractor.py
+# build helptags for (Neo)Vim
+vim --clean -E --cmd 'helptags third_party/vim/runtime/doc | quit'
+nvim --clean --headless --cmd 'helptags third_party/neovim/runtime/doc | quit'
+
+python3 help_tag_extractor.py

--- a/update_tags.sh
+++ b/update_tags.sh
@@ -9,7 +9,7 @@ git -C third_party/vim pull
 git -C third_party/neovim pull
 
 # build helptags for (Neo)Vim
-vim --clean -E --cmd 'helptags third_party/vim/runtime/doc | quit'
-nvim --clean --headless --cmd 'helptags third_party/neovim/runtime/doc | quit'
+vim --clean -e --cmd 'helptags third_party/vim/runtime/doc | quit'
+vim --clean -e --cmd 'helptags third_party/neovim/runtime/doc | quit'
 
-python3 help_tag_extractor.py
+python help_tag_extractor.py


### PR DESCRIPTION
Parses the `tags` file that lives in `$VIMRUNTIME/doc/` instead of globbing and parsing ***all*** `*.txt` files in `$VIMRUNTIME/doc/`. This brings the number of lines to parse in Python from from ~200,000 to ~10,000 for Vim, and from ~100,000 to ~9000 for Neovim. Neovim has additional overhead, as we have to generate the `tags` file with `:helptags` first.

Also, cloned Vim and Neovim repositories now live in a `third_party` directory, to avoid polluting the file system outside of this repository.

Resolves #28 