### PR TITLE
Find tags with trailing punctuation

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -33,7 +33,7 @@ class Bot:
         # First match inside backticks. If that fails fallback to match until first space.
         # TODO: Does it match every topic?
         match_text_with_backtick = r"`:(h|he|hel|help) (.*?)`"
-        match_text_with_space = r":(h|he|hel|help) ([^\s]+)"
+        match_text_with_space = r":(h|he|hel|help) ([^\s]+)[,.;:]?"
 
         self.match_re_space = re.compile(match_text_with_space, re.IGNORECASE)
         self.match_re_backtick = re.compile(
@@ -226,13 +226,17 @@ class Bot:
             if topic in replied_topics:
                 continue
 
-            # Create the link by by adjoining .txt after the matched part.
-            # TODO: Is this the correct approach?
-
             # Search in DB
             result = self.search_tag(topic, subreddit)
-            print(result)
             if result is None:
+                # If end is one of [,.;:], try again
+                # after stripping trailing punctuation
+                if topic[-1] in [',', '.', ';', ':']:
+                    topic = topic[0:-1]
+                    result = self.search_tag(topic, subreddit)
+
+            if result is None:
+                # still no matches
                 print("Tag not found")
                 self.create_github_issue(topic, link)
             else:

--- a/test_bot.py
+++ b/test_bot.py
@@ -126,6 +126,34 @@ class TestBot(unittest.TestCase):
         for tag in backtick_tags + space_tags:
             self.assertIn(tag, reply);
 
+    def test_punctuation_retry(self):
+        """
+        Test that bot finds tags that don't
+        match because of punctuation, but would
+        match otherwise.
+
+        e.g. In the string, "You should look at :h help."
+        """
+
+        bot = Bot()
+        tags = ["'formatlistpat'", "g:var", "c_CTRL-SHIFT-V",
+                ":lhelpgrep", ":viusage", "quote.", "+extra",
+                ":import-cycle"]
+        punct = [',', '.', ';', ':']*2
+        text = "Test comment: "
+        for tag, punct in zip(tags, punct):
+            text = text + " :h " + tag + punct
+
+        reply = bot.create_comment(text, "vim")
+        self.assertNotEqual(reply, '')
+        for tag in tags:
+            self.assertIn(tag, reply)
+
+        reply = bot.create_comment(text, "neovim")
+        self.assertNotEqual(reply, '')
+        for tag in tags:
+            self.assertIn(tag, reply);
+
     def test_url_encoding(self):
         """
         Test that bot url encodes /


### PR DESCRIPTION
This commit attempts to better match tags when used in sentences with
punctuation. If a whitespace-style match is not found, but the last
character is one of the common punctuation characters in text (",", ".", ";", ":"),
the bot will strip the trailing punctuation to try again.

I figured that this would catch the following common cases:

> You should check out :h 'formatlistpat'.

> These could be helpful: :h :exec, :h :normal, and :h :nnoremap.

> From :h 'scrolloff': *blah*

This even works when you try something you really shouldn't, like:

> You can use :h quote..

This would break here:

> You can use :h quote.

finding `:h quote.` instead of `:h quote`, but in a case like that you really should
use backticks, anyways.

If you can think of additional common cases, let me know!

Resolves #11.